### PR TITLE
change ProtocolVersion from 1 to 0

### DIFF
--- a/gdbus_watcher.c
+++ b/gdbus_watcher.c
@@ -217,8 +217,7 @@ static GVariant * handle_get_property(GDBusConnection *connection, const gchar *
 		ret = g_variant_new_boolean(size > 0);
 	}
 	else if(g_strcmp0(prop_name, "ProtocolVersion") == 0) {
-		//TODO find out what this should actually be
-		ret = g_variant_new_int32(1);
+		ret = g_variant_new_int32(0);
 	}
 	return ret;
 }


### PR DESCRIPTION
KDE (up to the current 5.54.0) refuses to use a StatusNotifierWatcher if its ProtocolVersion is not 0.

https://github.com/KDE/knotifications/blob/v5.54.0/src/kstatusnotifieritem.cpp#L741
https://github.com/KDE/knotifications/blob/v5.54.0/src/kstatusnotifieritem.cpp#L851-L857